### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/simple_jsonapi/rails/action_controller/request_validator.rb
+++ b/lib/simple_jsonapi/rails/action_controller/request_validator.rb
@@ -4,7 +4,7 @@ module SimpleJsonapi
       class RequestValidator
         attr_reader :request, :params
 
-        delegate :body, :content_type, :accept, :path, to: :request, prefix: true
+        delegate :body, :content_type, :media_type, :accept, :path, to: :request, prefix: true
 
         def initialize(request, params)
           @request = request
@@ -12,7 +12,11 @@ module SimpleJsonapi
         end
 
         def valid_content_type_header?
-          !request_has_body? || request_content_type == SimpleJsonapi::MIME_TYPE
+          if request.respond_to?(:media_type)
+            !request_has_body? || request_media_type == SimpleJsonapi::MIME_TYPE
+          else
+            !request_has_body? || request_content_type == SimpleJsonapi::MIME_TYPE
+          end
         end
 
         def valid_accept_header?

--- a/lib/simple_jsonapi/rails/railtie.rb
+++ b/lib/simple_jsonapi/rails/railtie.rb
@@ -14,17 +14,32 @@ module SimpleJsonapi
           # In the renderers, `self` is the controller
 
           ::ActionController::Renderers.add(:jsonapi_resource) do |resource, options|
-            self.content_type ||= Mime[:jsonapi]
+            if respond_to?(:media_type)
+              self.content_type = Mime[:jsonapi] unless self.media_type
+            else
+              self.content_type ||= Mime[:jsonapi]
+            end
+
             SimpleJsonapi.render_resource(resource, options).to_json
           end
 
           ::ActionController::Renderers.add(:jsonapi_resources) do |resources, options|
-            self.content_type ||= Mime[:jsonapi]
+            if respond_to?(:media_type)
+              self.content_type = Mime[:jsonapi] unless self.media_type
+            else
+              self.content_type ||= Mime[:jsonapi]
+            end
+
             SimpleJsonapi.render_resources(resources, options).to_json
           end
 
           ::ActionController::Renderers.add(:jsonapi_errors) do |errors, options|
-            self.content_type ||= Mime[:jsonapi]
+            if respond_to?(:media_type)
+              self.content_type = Mime[:jsonapi] unless self.media_type
+            else
+              self.content_type ||= Mime[:jsonapi]
+            end
+
             SimpleJsonapi.render_errors(errors, options).to_json
           end
         end


### PR DESCRIPTION
Modifying the gem to check `media_type` if it's defined (i.e. Rails 6). This gets rid of a bunch of deprecation warnings as Rails 6.1 is going to change the output of `content_type`.